### PR TITLE
handle backslash as path delimiter

### DIFF
--- a/src/mapper/entry.ts
+++ b/src/mapper/entry.ts
@@ -14,6 +14,7 @@ function ensureEndSlash(p: string) {
 }
 
 const escapeRegExp = (s: string) => s.replace(/[-\/\\^$*+?.()|[\]{}]/g, "\\$&")
+  .replace(/(\\\\|\\\/)/g, "[\\\\|\/]")
 
 export class Entry {
 
@@ -76,6 +77,7 @@ export class Entry {
 
   public getUrl(rel: string) {
     return path.join(this.urlRoot, rel)
+      .replace(/\\/g, "/")
   }
 
   public toString() {


### PR DESCRIPTION
On a windows system, backslash's are injected into the url and tag strings.  The edit at line 17 alters the regex to allow successful compares against either escaped delimiter '\\' or '\/'.  While the edit at line 80 replaces '\' with '/' when constructing url's.

Have a look at your convenience.  